### PR TITLE
Image name and pull secret are now templates

### DIFF
--- a/helm/api-tooling-api-notebook-core/templates/_helpers.tpl
+++ b/helm/api-tooling-api-notebook-core/templates/_helpers.tpl
@@ -1,0 +1,28 @@
+{{/*
+Generate the image name with the registry host and org. If host or org are not
+passed in then omit them.
+Keeps the values tidy and intentional.
+*/}}
+{{- define "image-name" -}}
+  {{- $image := list .Values.image.registry .Values.image.org .Values.image.name -}}
+  {{/* remove empty values in the list */}}
+  {{- $image := without $image "" -}}
+  {{/* join the reminaing string to form a docker hostname */}}
+  {{- $image := $image | join "/" }}
+  {{- $tag := default "latest" .Values.image.tag }}
+  {{- printf "%s:%s" $image $tag -}}
+{{- end -}}
+
+{{/*
+Generate a name for image registry pull secret if missing or used
+passed in value. Also generates the imagePullSecret block
+*/}}
+{{- define "image-pull-secret-name" -}}
+  {{- if or (.Values.image.pullSecret) (.Values.image.pullSecretName) }}
+    {{- $name := default .Chart.Name .Values.nameOverride -}}
+    {{- $secret := printf "%s-pull-secret" $name -}}
+    {{- $sm := default $secret .Values.image.pullSecretName -}}
+imagePullSecrets:
+- name: {{ $sm }}
+  {{- end }}
+{{- end -}}

--- a/helm/api-tooling-api-notebook-core/templates/api-nootebook.yaml
+++ b/helm/api-tooling-api-notebook-core/templates/api-nootebook.yaml
@@ -45,12 +45,11 @@ spec:
         name: api-notebook-service
         k8s-app: api-notebook
     spec:
+{{ include "image-pull-secret-name" . | indent 6 }}
       containers:
         - name: api-notebook-service
-          image: "{{.Values.image.registry}}/{{.Values.image.org}}/{{.Values.image.name}}:{{default "latest" .Values.image.tag}}"
+          image: "{{ template "image-name" . }}"
           imagePullPolicy: Always
       volumes:
         - name: api-notebook-service-storage
           emptyDir: {}
-      imagePullSecrets:
-        - name: devdocker-registrykey


### PR DESCRIPTION
the image pull secret function makes the secret name configurable, valkyr now passes that name in
The image name is now templated and does not require a registry host and org. Allows using local registries if needed