### PR TITLE
Fix invalid regex

### DIFF
--- a/config/default.js
+++ b/config/default.js
@@ -4,7 +4,7 @@ module.exports = {
     title:         process.env.TITLE ? process.env.TITLE : 'Notebook Site',
     oauthCallback: process.env.OAUTH_CALLBACK ? process.env.OAUTH_CALLBACK : '/authenticate/oauth.html'
   },
-  domainRegex:  [/https?:\/\/[^/]*\.anypoint\.mulesoft\.com\/(.+)/g,
+  domainRegex:  [/https?:\/\/[^\/]*\.anypoint\.mulesoft\.com\/(.+)/g,
     /https?:\/\/anypoint\.mulesoft\.com\/(.+)/g,
     /https?:\/\/[^\/]*\.cloudhub\.io\/(.+)/g,
     /https?:\/\/[^\/]*\.msap\.io\/(.+)/g,


### PR DESCRIPTION
This is an attempt to solve the issue whereby Notebooks hosted at `https://api-notebook.anypoint.mulesoft.com/notebooks/#<gist_id>` (E.g. https://api-notebook.anypoint.mulesoft.com/notebooks/#380297ed0e474010ff43) are not displaying anymore

I haven't had time to do so but it would be nice to add some tests so as to prevent this kind of issue to re-surface in the future. 